### PR TITLE
Digital librarian: LIBRARIAN.md, collection metadata, and findings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-# All collection data — copyright material, not for redistribution
-collections/
+# Collection PDFs and indexed output — copyright material, not for redistribution
+collections/*/pdfs
+collections/*/indexed
+
+# Research findings — personal, may be a cloud symlink
+findings/
 
 # Downloads in progress
 Downloads/

--- a/CATALOGUE.md
+++ b/CATALOGUE.md
@@ -1,0 +1,26 @@
+# Library Catalogue
+
+All collections in this library. See each collection's `COLLECTION.md` for full details.
+
+| Collection | Period | Publications | Pages | Status |
+| --- | --- | --- | --- | --- |
+| [Hobby Electronics](collections/hobby-electronics/COLLECTION.md) | 1978–1984 | 67 | ~5,000 | Indexed |
+| [ETI — Electronics Today International](collections/eti/COLLECTION.md) | 1972–1999 | 367 | 27,328 | Indexed |
+| [Bernards/Babani BP Books](collections/bernards-babani/COLLECTION.md) | Various | 111 | 16,153 | Indexed |
+
+---
+
+## Adding a collection
+
+```bash
+# 1. Download
+python3 download.py "SOURCE-URL" --output-dir collections/NAME/pdfs
+
+# 2. Probe structure
+python3 convert.py --analyze --input-dir collections/NAME/pdfs
+
+# 3. Convert
+python3 convert.py --input-dir collections/NAME/pdfs --output-dir collections/NAME/indexed
+```
+
+Then create `collections/NAME/COLLECTION.md` and add a row to this catalogue.

--- a/LIBRARIAN.md
+++ b/LIBRARIAN.md
@@ -1,0 +1,134 @@
+# Librarian's Guide
+
+This is a **personal digital library** of scanned publications — magazines and books indexed for research,
+search, and AI-assisted discovery.
+
+If you are an AI assistant reading this file, you now have everything you need to act as an informed librarian
+for this collection. Read this guide once, then navigate freely.
+
+---
+
+## What this library contains
+
+Scanned publications from online archives (primarily [World Radio History](https://www.worldradiohistory.com)),
+converted to searchable Markdown with rendered page images. Each publication in the library has:
+
+- Full OCR text extracted from the scan
+- Every page rendered as a PNG image at 200 DPI (~1600 × 2250 px)
+- An index of detected article/section headings
+
+See [`CATALOGUE.md`](CATALOGUE.md) for a list of all collections and their status.
+
+---
+
+## Library structure
+
+```text
+collections/
+├── COLLECTION-NAME/
+│   ├── COLLECTION.md         ← metadata: source, date range, coverage, known gaps
+│   ├── pdfs/                 ← source PDFs (gitignored; may be a symlink to cloud storage)
+│   └── indexed/
+│       ├── index.md          ← master index linking all publications in this collection
+│       └── SLUG/             ← one directory per publication
+│           ├── index.md      ← page-by-page heading list for this publication
+│           ├── content.md    ← full OCR text with page images embedded inline
+│           └── pages/
+│               └── page-NNN.png   ← each page at 200 DPI
+
+findings/                     ← research outputs (gitignored; may be a symlink to cloud storage)
+```
+
+---
+
+## How to orient yourself
+
+1. Read `CATALOGUE.md` — one-line summary of every collection
+2. Read a `collections/NAME/COLLECTION.md` — source, coverage, known gaps for that collection
+3. Read `collections/NAME/indexed/index.md` — every publication in the collection, one line each
+4. Read a publication's `index.md` — page-by-page headings, fast to scan for topics
+5. Read a publication's `content.md` — full text with embedded `![Page N](pages/page-NNN.png)` images
+
+---
+
+## How to search
+
+### Keyword search (fast)
+
+```bash
+# Which publications mention a topic?
+grep -ril "fuzz box" collections/hobby-electronics/indexed/
+
+# Show the matching lines with context
+grep -in -C3 "fuzz box" collections/hobby-electronics/indexed/*/content.md
+
+# Search across all collections
+grep -ril "synthesiser" collections/*/indexed/
+```
+
+### Reading the index files (AI-preferred)
+
+Publication `index.md` files list headings by page number — they are fast to read and give a clear
+picture of an issue's contents without loading the full text. Start here when scanning for topics.
+
+```text
+p.13 — Mini Synth
+p.17 — Circuit Description
+p.21 — Parts List
+```
+
+### Viewing a page
+
+Page images are embedded inline in `content.md`. To view a specific page directly, open:
+`collections/NAME/indexed/SLUG/pages/page-NNN.png`
+
+---
+
+## How to write findings
+
+Research outputs — topic references, cross-collection notes, article summaries — belong in the `findings/`
+folder. This folder is gitignored and can be a symlink to a cloud folder (Dropbox, iCloud, Google Drive)
+for cross-device access.
+
+Suggested structure:
+
+```text
+findings/
+├── topics/
+│   ├── synthesisers.md
+│   ├── audio-amplifiers.md
+│   └── ...
+├── projects/
+│   └── ...
+└── sessions/
+    └── YYYY-MM-DD-topic.md
+```
+
+Write findings freely — they will never be committed to the repository.
+
+---
+
+## Important limitations
+
+| Limitation | Detail |
+| --- | --- |
+| OCR quality varies | Early issues (1970s) can have lower accuracy; handwritten annotations are not captured |
+| Diagrams are page images | Circuit diagrams are baked into the page scan — read them from the PNG, not the text |
+| Some issues are scan-only | A small number of PDFs have no OCR layer; their `content.md` will contain only page images |
+| Slug collisions | Where multiple PDFs share the same date/issue number, one may overwrite another's slug |
+
+---
+
+## Quick reference
+
+| Task | Command / File |
+| --- | --- |
+| List all collections | `CATALOGUE.md` |
+| See what a collection covers | `collections/NAME/COLLECTION.md` |
+| Browse all issues in a collection | `collections/NAME/indexed/index.md` |
+| Scan an issue's contents | `collections/NAME/indexed/SLUG/index.md` |
+| Read full text of an issue | `collections/NAME/indexed/SLUG/content.md` |
+| Search across a collection | `grep -ril "term" collections/NAME/indexed/` |
+| Write a research finding | `findings/topics/YOUR-TOPIC.md` |
+| Download a new collection | `python3 download.py URL --output-dir collections/NAME/pdfs` |
+| Convert a collection | `python3 convert.py --input-dir collections/NAME/pdfs --output-dir collections/NAME/indexed` |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
 # publication-archive
 
-Tools for downloading and indexing magazine and book PDFs from online archives,
-making them searchable and queryable via grep or an AI assistant.
+A **personal digital library** toolkit for building a local, searchable corpus of scanned publications —
+magazines, books, and periodicals from online archives.
 
-Originally built around [World Radio History](https://www.worldradiohistory.com),
-but the tools work with any collection of PDFs that have an OCR text layer.
+Once built, the library is navigable by grep, by hand, or by any AI assistant. An AI with access to the
+indexed corpus can act as an informed librarian immediately — searching, cross-referencing, and surfacing
+insights across thousands of pages.
+
+> See [`LIBRARIAN.md`](LIBRARIAN.md) for the AI orientation guide.
+
+---
+
+## How it works
+
+1. **Download** — scrape PDF links from an archive page and download them locally
+2. **Convert** — extract OCR text and render each page as a PNG, producing searchable Markdown
+3. **Search** — grep, browse, or open the library in an AI-assisted editor and query in plain English
+4. **Record** — write research findings to `findings/` (gitignored; can sync via Dropbox or iCloud)
+
+The `collections/` directory holds your library. PDFs and indexed output are gitignored so no
+copyrighted material ever enters the repository. Collection metadata (`COLLECTION.md`) *is* tracked,
+so the shape of your library is version-controlled even if the contents are not.
+
+---
 
 ## Requirements
 
@@ -14,12 +32,16 @@ pip3 install pymupdf
 
 Python 3.10+. No other dependencies.
 
+---
+
 ## Tools
 
 | Script | Purpose |
 | --- | --- |
 | `download.py` | Scrape all PDF links from an archive page and download them |
 | `convert.py` | Convert a folder of PDFs to searchable Markdown with page images |
+
+---
 
 ## Workflow
 
@@ -57,12 +79,12 @@ python3 convert.py \
 Each PDF becomes a directory containing:
 
 - `content.md` — full OCR text with page images embedded inline
-- `index.md` — detected article/section titles
+- `index.md` — page-by-page article and section headings
 - `pages/page-NNN.png` — each page rendered at 200 DPI
 
 A master `index.md` is written to the output root linking all publications.
 
-### 4. Search
+### 4. Search and research
 
 ```bash
 # Find all publications mentioning a topic
@@ -72,45 +94,61 @@ grep -ril "VCA\|voltage controlled amplifier" collections/eti/indexed/
 grep -in -A3 "fuzz box" collections/*/indexed/*/content.md
 ```
 
-Or open the `indexed/` directory in an AI-assisted editor and query across the full archive in natural language.
+Or open the `collections/` directory in [Claude Code](https://claude.ai/code) (or any AI-assisted
+editor) and ask questions in plain English:
 
-### Querying with an AI assistant
-
-Once indexed, open your `collections/` directory in [Claude Code](https://claude.ai/code) (or any AI-assisted editor)
-and ask questions in plain English. For example, with a Hobby Electronics collection:
-
-> *"There's a Guitar Fuzz Box project in HE Magazine. Please find it for me."*
+> *"There's a Guitar Fuzz Box project in Hobby Electronics magazine. Please find it for me."*
 >
-> *"Can you open the Feb 1982 Noiseless Fuzz Box issue for me to see?"*
+> *"Are there any synthesiser projects across the whole collection?"*
 >
-> *"Are there any synthesiser projects?"*
+> *"What does the ETI Transcendent Polysynth series cover, and which issues should I read first?"*
 
-The AI can read `content.md` files, follow links to page images, and reason across hundreds of issues at once —
-turning a static archive into a searchable knowledge base.
+The AI reads `LIBRARIAN.md` and the collection index files to orient itself, then navigates freely.
 
-## Example collections
+### 5. Record findings
 
-The following collections from [World Radio History](https://www.worldradiohistory.com) have been tested with these tools:
+Write research outputs to `findings/` — topic references, cross-collection notes, article summaries.
+This folder is gitignored. To share findings across devices, make it a symlink to a cloud folder:
 
-| Collection | Source page | PDFs | Pages |
+```bash
+# Example: link findings to a Dropbox folder
+ln -s ~/Dropbox/my-library-findings findings
+```
+
+---
+
+## Library catalogue
+
+See [`CATALOGUE.md`](CATALOGUE.md) for all collections. Example collections tested with these tools:
+
+| Collection | Period | PDFs | Pages |
 | --- | --- | --- | --- |
-| Hobby Electronics (1978–1984) | [Hobby Electronics](https://www.worldradiohistory.com/Hobby_Electronics.htm) | 67 | ~5,000 |
-| ETI UK (1972–1999) | [ETI Magazine](https://www.worldradiohistory.com/ETI_Magazine.htm) | 367 | 27,328 |
-| Bernards/Babani BP Books | [Bernards & Babani Bookshelf](https://www.worldradiohistory.com/Bookshelf_Bernards_Babani.htm) | 111 | 16,153 |
+| [Hobby Electronics](collections/hobby-electronics/COLLECTION.md) | 1978–1984 | 67 | ~5,000 |
+| [ETI — Electronics Today International](collections/eti/COLLECTION.md) | 1972–1999 | 367 | 27,328 |
+| [Bernards/Babani BP Books](collections/bernards-babani/COLLECTION.md) | Various | 111 | 16,153 |
+
+---
 
 ## Using as a template
 
-Click **Use this template** on GitHub to create your own archive repository. Add your collections to the `collections/`
-directory — it is excluded by `.gitignore` so copyrighted content stays local.
+Click **Use this template** on GitHub to create your own library repository. The `collections/` PDFs
+and indexed output are excluded by `.gitignore`, but collection metadata (`COLLECTION.md` files) and
+research findings structure are tracked — so the shape of your library is preserved in version control.
+
+---
 
 ## Contributing
 
 Bug reports and enhancement requests are welcome via
 [GitHub Issues](https://github.com/ali5ter/publication-archive/issues).
 
+---
+
 ## Copyright notice
 
-PDFs and all converted output are derived from copyrighted material. This repository contains **only the scripts**.
-The `collections/` directory is excluded via `.gitignore` and must not be committed or redistributed.
+PDFs and all converted output are derived from copyrighted material. This repository contains
+**only the scripts and metadata**. Collection PDFs and indexed output are excluded via `.gitignore`
+and must not be committed or redistributed.
 
-Source PDFs can be downloaded from [World Radio History](https://www.worldradiohistory.com) for personal use.
+Source PDFs can be downloaded from [World Radio History](https://www.worldradiohistory.com) for
+personal use.

--- a/collections/bernards-babani/COLLECTION.md
+++ b/collections/bernards-babani/COLLECTION.md
@@ -1,0 +1,48 @@
+# Bernards/Babani BP-Numbered Books
+
+Practical electronics books published under the Bernards and Babani Press imprints, identified by
+their "BP" catalogue numbers. Compact, project-focused books covering a wide range of electronics topics.
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| **Source** | [World Radio History](https://www.worldradiohistory.com/Bookshelf_Bernards_Babani.htm) |
+| **Period** | Various (1960s–1990s) |
+| **Publications** | 111 BP-numbered books |
+| **Pages** | 16,153 |
+| **Local PDFs** | `collections/bernards-babani/pdfs/UK/` |
+| **Indexed** | `collections/bernards-babani/indexed/` — 112 directories |
+
+## Filter applied
+
+Only BP-numbered titles were downloaded (filename contains `BP` followed by digits, e.g. `BP107`,
+`Babani-BP105`, `Bernards-BP38`). Non-BP Bernards titles (B-series, general reference books)
+were excluded.
+
+## Slug format
+
+Books are indexed by their BP number:
+
+```text
+indexed/
+├── 35/      ← BP35
+├── 107/     ← BP107
+├── 185/     ← BP185 (Electronic Synthesiser Construction)
+...
+└── 331/     ← BP331
+```
+
+## Coverage notes
+
+- Both Bernards and Babani used the same BP number sequence but occasionally reused numbers
+  for different titles — a small number of slug collisions may result
+- Two filenames contain non-ASCII characters (`ñ`) and required URL encoding to download correctly
+- Some early books have lower OCR quality due to typewritten originals
+
+## Content character
+
+Concise practical guides: construction projects, circuit design, component references, and
+introductory tutorials. Topics span audio, RF, computing interfaces, electronic music, and
+test equipment. Key synthesiser titles: **BP185** (*Electronic Synthesiser Construction*),
+**BP329** (*Electronic Music Learning Projects*), **BP331** (*A Beginner's Guide to MIDI*).

--- a/collections/eti/COLLECTION.md
+++ b/collections/eti/COLLECTION.md
@@ -1,0 +1,58 @@
+# ETI — Electronics Today International
+
+Monthly electronics magazine with UK and Australian editions. One of the leading hobbyist
+electronics titles of the 1970s–1990s, with strong project content and technical features.
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| **Source** | [World Radio History](https://www.worldradiohistory.com/ETI_Magazine.htm) |
+| **Period** | 1972–1999 |
+| **Publications** | 367 PDFs |
+| **Pages** | 27,328 |
+| **Local PDFs** | `collections/eti/pdfs/` |
+| **Indexed** | `collections/eti/indexed/` — 327 directories |
+
+## Directory structure
+
+The source archive uses decade subdirectories:
+
+```text
+pdfs/
+├── Archive-Electronics-Today/    ← Australian/early issues
+└── UK/
+    └── Electronics-Today-UK/
+        ├── 70s/
+        ├── 80s/
+        └── 90s/
+```
+
+Conversion uses `--pattern **/*.pdf` to recurse into all subdirectories.
+
+## Slug format
+
+Most issues: `YYYY-MM`. Special publications use volume or issue identifiers:
+
+```text
+indexed/
+├── 1972-09/
+├── ...
+├── 1999-12/
+├── vol-2/           ← special/annual volumes
+├── no-5/            ← numbered specials
+└── eti-lab-notes-and-data/
+```
+
+## Coverage notes
+
+- 367 PDFs downloaded; 327 indexed directories (approximately 40 slug collisions
+  where PDFs from different decade subdirectories resolved to the same output slug)
+- 9 late-1990s issues have no OCR layer — `content.md` will contain only page images
+- The UK and Australian editions sometimes covered different projects in the same month
+
+## Content character
+
+Broad technical coverage: audio, RF, synthesisers (notably the multi-issue Transcendent Polysynth
+series, 1980–1981), microcomputers, test equipment, and component tutorials. OCR quality is
+generally good for 1970s–1980s issues; variable for 1990s.

--- a/collections/hobby-electronics/COLLECTION.md
+++ b/collections/hobby-electronics/COLLECTION.md
@@ -1,0 +1,40 @@
+# Hobby Electronics
+
+Monthly electronics magazine published in the UK by Argus Specialist Publications.
+Aimed at hobbyists building practical projects — audio, radio, computing, and test equipment.
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| **Source** | [World Radio History](https://www.worldradiohistory.com/Hobby_Electronics.htm) |
+| **Period** | November 1978 – September 1984 |
+| **Publications** | 67 issues |
+| **Pages** | ~5,000 |
+| **Local PDFs** | `collections/hobby-electronics/pdfs/` (symlink to cloud storage) |
+| **Indexed** | `collections/hobby-electronics/indexed/` |
+
+## Slug format
+
+Issues are named by year and month: `YYYY-MM`
+
+```text
+indexed/
+├── 1978-11/
+├── 1978-12/
+├── 1979-01/
+...
+└── 1984-09/
+```
+
+## Coverage notes
+
+- All 67 available issues are indexed
+- The archive on World Radio History appears to be complete for this title
+- March 1981 issue is absent from the source archive
+
+## Content character
+
+Heavy on construction projects: audio amplifiers, synthesisers, guitar effects, radio receivers,
+test equipment, and early home computing. Circuit diagrams accompany most projects.
+Good OCR quality throughout.


### PR DESCRIPTION
## Summary

Transforms publication-archive from a download/convert toolchain into a fully-framed **personal digital library** that any AI assistant can navigate without warmup.

- **`LIBRARIAN.md`** — AI orientation guide explaining library structure, navigation patterns, search strategies, and findings workflow. Any AI reading this file can act as an informed librarian immediately.
- **`CATALOGUE.md`** — master cross-collection index with links to each collection's metadata.
- **`collections/*/COLLECTION.md`** — per-collection metadata for Hobby Electronics, ETI, and Bernards/Babani: source URL, period, publication count, page count, slug format, and known gaps.
- **`.gitignore`** — updated from broad `collections/` exclusion to targeted `collections/*/pdfs` and `collections/*/indexed`, so `COLLECTION.md` files are now version-controlled while copyrighted content stays local.
- **`README.md`** — reframed around the personal digital library concept with AI librarian examples.

## Test plan

- [ ] `markdownlint` passes with zero errors
- [ ] `COLLECTION.md` files appear in `git status` (not ignored)
- [ ] `collections/hobby-electronics/pdfs` symlink is still ignored
- [ ] `collections/eti/indexed/` is still ignored
- [ ] README renders correctly on GitHub

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)