### PR TITLE
Add agent context files for Claude Code, Codex, Gemini CLI, and Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+# GitHub Copilot Instructions
+
+This repository is a **personal digital library** toolkit for building a local, searchable corpus of
+scanned publications — magazines, books, and periodicals.
+
+## Start here
+
+Read [`LIBRARIAN.md`](../LIBRARIAN.md) before navigating the collections. It explains:
+
+- How the library is structured (`collections/NAME/indexed/SLUG/`)
+- How to read `index.md` and `content.md` files
+- How to search across the corpus
+- How to write research findings to `findings/`
+
+## Quick reference
+
+| Task | Location |
+| --- | --- |
+| All collections | `CATALOGUE.md` |
+| Collection details | `collections/NAME/COLLECTION.md` |
+| Browse a collection | `collections/NAME/indexed/index.md` |
+| Scan an issue | `collections/NAME/indexed/SLUG/index.md` |
+| Read full text | `collections/NAME/indexed/SLUG/content.md` |
+| Write findings | `findings/` (gitignored) |
+
+## Tools
+
+```bash
+python3 download.py "URL" --output-dir collections/NAME/pdfs
+python3 convert.py --input-dir collections/NAME/pdfs --output-dir collections/NAME/indexed
+```
+
+## Notes
+
+- PDFs and indexed output are gitignored — copyrighted material stays local
+- Page images are at `collections/NAME/indexed/SLUG/pages/page-NNN.png`
+- Some issues have no OCR layer; their `content.md` contains only page image references

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Instructions
+
+This repository is a **personal digital library** toolkit for building a local, searchable corpus of
+scanned publications — magazines, books, and periodicals.
+
+## Start here
+
+Read [`LIBRARIAN.md`](LIBRARIAN.md) before navigating the collections. It explains:
+
+- How the library is structured (`collections/NAME/indexed/SLUG/`)
+- How to read `index.md` and `content.md` files
+- How to search across the corpus
+- How to write research findings to `findings/`
+
+## Quick reference
+
+| Task | Location |
+| --- | --- |
+| All collections | `CATALOGUE.md` |
+| Collection details | `collections/NAME/COLLECTION.md` |
+| Browse a collection | `collections/NAME/indexed/index.md` |
+| Scan an issue | `collections/NAME/indexed/SLUG/index.md` |
+| Read full text | `collections/NAME/indexed/SLUG/content.md` |
+| Write findings | `findings/` (gitignored) |
+
+## Tools
+
+```bash
+python3 download.py "URL" --output-dir collections/NAME/pdfs
+python3 convert.py --input-dir collections/NAME/pdfs --output-dir collections/NAME/indexed
+```
+
+## Notes
+
+- PDFs and indexed output are gitignored — copyrighted material stays local
+- Page images are at `collections/NAME/indexed/SLUG/pages/page-NNN.png`
+- Some issues have no OCR layer; their `content.md` contains only page image references

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,15 @@
 # publication-archive — AI Context
 
+## Library orientation
+
+**Read [`LIBRARIAN.md`](LIBRARIAN.md) before navigating the collections.** It explains the library
+structure, how to find and read index files, how to search, and how to write findings.
+
 ## Purpose
 
-Tools for downloading and indexing magazine/book PDFs from online archives, making them searchable via AI or grep.
-Originally built for [World Radio History](https://www.worldradiohistory.com) but works with any collection of PDFs.
+A personal digital library toolkit. Downloads and indexes magazine/book PDFs from online archives into
+searchable Markdown with page images, making the corpus navigable by grep or AI assistant.
+Originally built for [World Radio History](https://www.worldradiohistory.com) but works with any PDF collection.
 
 ## Project layout
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,37 @@
+# Gemini Instructions
+
+This repository is a **personal digital library** toolkit for building a local, searchable corpus of
+scanned publications — magazines, books, and periodicals.
+
+## Start here
+
+Read [`LIBRARIAN.md`](LIBRARIAN.md) before navigating the collections. It explains:
+
+- How the library is structured (`collections/NAME/indexed/SLUG/`)
+- How to read `index.md` and `content.md` files
+- How to search across the corpus
+- How to write research findings to `findings/`
+
+## Quick reference
+
+| Task | Location |
+| --- | --- |
+| All collections | `CATALOGUE.md` |
+| Collection details | `collections/NAME/COLLECTION.md` |
+| Browse a collection | `collections/NAME/indexed/index.md` |
+| Scan an issue | `collections/NAME/indexed/SLUG/index.md` |
+| Read full text | `collections/NAME/indexed/SLUG/content.md` |
+| Write findings | `findings/` (gitignored) |
+
+## Tools
+
+```bash
+python3 download.py "URL" --output-dir collections/NAME/pdfs
+python3 convert.py --input-dir collections/NAME/pdfs --output-dir collections/NAME/indexed
+```
+
+## Notes
+
+- PDFs and indexed output are gitignored — copyrighted material stays local
+- Page images are at `collections/NAME/indexed/SLUG/pages/page-NNN.png`
+- Some issues have no OCR layer; their `content.md` contains only page image references


### PR DESCRIPTION
## Summary

Adds the standard context/instruction files for popular AI coding assistants so any of them
can orient themselves to the library without user prompting.

| File | Agent |
| --- | --- |
| `CLAUDE.md` | Claude Code — added library orientation pointer to `LIBRARIAN.md` |
| `AGENTS.md` | OpenAI Codex CLI |
| `GEMINI.md` | Google Gemini CLI |
| `.github/copilot-instructions.md` | GitHub Copilot |

All files are concise and consistent: identify the project as a personal digital library,
direct the agent to `LIBRARIAN.md` for full orientation, and include a quick-reference table.

## Test plan

- [ ] markdownlint passes with zero errors
- [ ] Each file renders correctly on GitHub
- [ ] `CLAUDE.md` opens with the library orientation section

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)