### PR TITLE
Fix year-month slug for space-separated filenames

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -45,7 +45,7 @@ except ImportError:
 # Patterns tried in order; first match wins
 _SLUG_PATTERNS: list[tuple[str, re.Pattern]] = [
     # PublicationName-YYYY-MM[...].pdf  →  YYYY-MM
-    ("year-month", re.compile(r".*?[_-](\d{4})[_-](\d{2})(?:[_-]|\.|$)", re.IGNORECASE)),
+    ("year-month", re.compile(r".*?[ _-](\d{4})[_-](\d{2})(?:[_-]|\.|$)", re.IGNORECASE)),
     # Vol-N or Volume-N  →  vol-N  (bare V excluded: too ambiguous, e.g. _v2 meaning version 2)
     ("volume", re.compile(r"(?:Vol(?:ume)?)[_\-\.\s]?(\d+)", re.IGNORECASE)),
     # No-N or Issue-N  →  no-N


### PR DESCRIPTION
## Summary

- Expands the `year-month` slug regex in `_SLUG_PATTERNS` to accept a space (in addition to `_` or `-`) before the four-digit year.
- Fixes filenames like `Elektor[nonlinear.ir] 1975-02_text.pdf` that were causing all months in a year to collapse into a single slug.

## Test plan

- [ ] Confirm `Elektor[nonlinear.ir] 1975-02_text.pdf` now produces slug `1975-02` instead of falling through to a bare-number match.
- [ ] Verify existing filenames with `_YYYY-MM` and `-YYYY-MM` separators still produce correct slugs.
- [ ] Run `python3 convert.py --analyze --input-dir <collection>` against a collection with space-separated filenames and confirm unique per-issue slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)