### PR TITLE
Fix convert.py: --global-index no longer requires --input-dir

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -581,7 +581,7 @@ def main() -> None:
         description="Convert archive PDFs (magazines, books) to searchable Markdown"
     )
     parser.add_argument("--analyze", action="store_true", help="Probe PDFs and report structure without converting")
-    parser.add_argument("--input-dir", type=Path, required=True, help="Source PDF directory")
+    parser.add_argument("--input-dir", type=Path, required=False, default=None, help="Source PDF directory")
     parser.add_argument("--output-dir", type=Path, default=Path("converted"), help="Output directory (default: ./converted)")
     parser.add_argument("--pattern", default="**/*.pdf", help="Glob pattern to select PDFs (default: **/*.pdf)")
     parser.add_argument("--dpi", type=int, default=200, help="Page image render DPI (default: 200)")
@@ -603,6 +603,9 @@ def main() -> None:
         output_path = Path("CATALOGUE.md")
         write_global_index(args.global_index, output_path)
         return
+
+    if not args.input_dir:
+        parser.error("--input-dir is required unless --global-index is specified")
 
     if not args.input_dir.exists():
         print(f"ERROR: Input directory not found: {args.input_dir}")


### PR DESCRIPTION
## Summary

- `--input-dir` was declared `required=True` in argparse, so it was validated before the `--global-index` early-exit could fire
- `python3 convert.py --global-index collections/` always failed with a misleading argparse error
- Makes `--input-dir` optional (`required=False`, default `None`) and adds an explicit `parser.error()` when neither `--global-index` nor `--input-dir` is supplied

Fixes #24

## Test plan

- [ ] `python3 convert.py --global-index collections/` — no longer fails with argparse error
- [ ] `python3 convert.py` (no args) — still fails with actionable error message
- [ ] `python3 convert.py --input-dir collections/NAME/pdfs` — normal conversion unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)