### PR TITLE
Fix corrupt PDF crash and --global-index field parsing for auto-generated COLLECTION.md

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -552,10 +552,10 @@ def write_global_index(collections_root: Path, output_path: Path) -> None:
             m = re.search(r"^# (.+)$", text, re.MULTILINE)
             if m:
                 name = m.group(1)
-            m = re.search(r"\|\s*\*\*Period\*\*\s*\|\s*(.+?)\s*\|", text)
+            m = re.search(r"\|\s*(?:\*\*Period\*\*|Date range)\s*\|\s*(.+?)\s*\|", text)
             if m:
                 period = m.group(1).strip()
-            m = re.search(r"\|\s*\*\*Pages\*\*\s*\|\s*(~?[\d,]+)\s*\|", text)
+            m = re.search(r"\|\s*(?:\*\*Pages\*\*|Total pages)\s*\|\s*(~?[\d,]+)\s*\|", text)
             if m:
                 pages = m.group(1).strip()
 
@@ -634,7 +634,11 @@ def main() -> None:
         base_slug, _ = parse_slug(pdf_path.name)
         resolved = slug_map[pdf_path]
         override = resolved if resolved != base_slug else None
-        info = convert_publication(pdf_path, args.output_dir, args.dpi, args.force, slug_override=override)
+        try:
+            info = convert_publication(pdf_path, args.output_dir, args.dpi, args.force, slug_override=override)
+        except Exception as exc:
+            print(f"  WARNING: skipping {pdf_path.name} — {exc}")
+            continue
         if info.get("slug"):
             write_publication_index(info, args.output_dir)
             all_pubs.append(info)


### PR DESCRIPTION
## Summary

- **Bug 1 — Corrupt PDF crash**: `convert_publication()` calls `fitz.open()`, which raises `pymupdf.FileDataError` on corrupt PDFs, aborting the entire run. Wraps the call in `try/except Exception` so the offending PDF is skipped with a warning and the run continues.
- **Bug 2 — `--global-index` misses auto-generated fields**: The `write_global_index()` parser matched only the hand-crafted bold format (`**Period**`, `**Pages**`) but `--write-collection-md` outputs plain-text labels (`Date range`, `Total pages`). Updated the two `re.search` regexes to match both formats via alternation, so Period and Pages populate correctly regardless of how COLLECTION.md was authored.

Both fixes were surfaced in the downstream instance ([ali5ter/electronics-publications-library@f8f8403](https://github.com/ali5ter/electronics-publications-library/commit/f8f8403)).

## Test plan

- [ ] Run `convert.py` against a directory that includes a corrupt PDF — confirm it logs `WARNING: skipping <file>` and continues rather than crashing
- [ ] Run `convert.py --write-collection-md` to generate an auto-format COLLECTION.md, then run `convert.py --global-index collections/` — confirm Period and Pages columns are populated in CATALOGUE.md
- [ ] Run the same `--global-index` against a hand-crafted COLLECTION.md with `**Period**`/`**Pages**` bold fields — confirm those still populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)